### PR TITLE
Update StompService.js

### DIFF
--- a/src/services/StompService.js
+++ b/src/services/StompService.js
@@ -18,7 +18,7 @@ function StompService($rootScope, ApplicationService, ElementService, URLService
     $http.get(URLService.getJMSHostname()).then(function successCallback(response) {
         if(response.data.connections[0].hasOwnProperty("uri")){
             var removeProtocol = response.data.connections[0].uri.replace(/.*?:\/\//g, "");
-            host = 'wss://' + removeProtocol.substring(0, removeProtocol.length-6) + ':61614';
+            host = 'ws://' + removeProtocol.substring(0, removeProtocol.length-6) + ':61614';
             stompConnect();
         }else{
             console.log('JSON does not contain the right key.  STOMP failed.');


### PR DESCRIPTION
for whatever reason, newer versions of activeMQ don't like the webapp connecting via 'wss'.  Changed to 'ws' and this works, and is also a sane default regardless.  This covers the real issue I had with #10 , but I do think that:
1) StompService is a misnomer (this is ws, clearly)
2) configurable port should be allowable and exposed